### PR TITLE
Fixed #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ func (mh myHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte("Hello World!"))
 }
 // later on
-http.Handle("/something", tracer.Tracer(myHandler{}))
+http.Handle("/something", tracer.NewHandler(myHandler{}))
 ```
 
 **Accessing the RequestID**

--- a/example.go
+++ b/example.go
@@ -43,7 +43,7 @@ func main() {
 		// write the request id into the response
 		_, _ = w.Write([]byte(tracer.GetRequestId(r)))
 	}))
-	http.Handle("/something", tracer.Tracer(myHandler{}))
+	http.Handle("/something", tracer.NewHandler(myHandler{}))
 	// start http server
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
 }

--- a/tracer/client.go
+++ b/tracer/client.go
@@ -41,6 +41,12 @@ func (rt *traceableRoundTripper) RoundTrip(r *http.Request) (res *http.Response,
 // Apply modifies an http client's transport to inject the X-Request-ID header
 func Apply(c *http.Client) {
 	log.Debug("injecting request tracing into http client")
-	rt := traceableRoundTripper{http.DefaultTransport}
+	var transport http.RoundTripper
+	if c.Transport == nil {
+		transport = http.DefaultTransport
+	} else {
+		transport = c.Transport
+	}
+	rt := traceableRoundTripper{transport}
 	c.Transport = &rt
 }

--- a/tracer/http_test.go
+++ b/tracer/http_test.go
@@ -54,3 +54,9 @@ func TestGetRequestId(t *testing.T) {
 
 	assert.Equal(t, "test", GetRequestId(r))
 }
+
+func TestGetContextId(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "id", "test")
+
+	assert.EqualValues(t, "test", GetContextId(ctx))
+}

--- a/tracer/middleware.go
+++ b/tracer/middleware.go
@@ -20,7 +20,7 @@ package tracer
 import "net/http"
 
 // Tracer provides an HTTP handler for injecting trace information
-func Tracer(h http.Handler) http.Handler {
+func NewHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// inject the requestId to the context
 		r = SetRequestId(r)

--- a/tracer/middleware_test.go
+++ b/tracer/middleware_test.go
@@ -35,7 +35,7 @@ func TestMiddleware(t *testing.T) {
 	req.Header.Add("X-Request-ID", "test-request-id")
 	w := httptest.NewRecorder()
 
-	h := Tracer(&handler{})
+	h := NewHandler(&handler{})
 	h.ServeHTTP(w, req)
 
 	resp := w.Result()


### PR DESCRIPTION
* client.Apply now uses the clients existing Transport
* Updated middleware.Tracer to NewHandler for naming consistency